### PR TITLE
fix: 统一手机端的图片DOM id 为 item.id，修复缩放与触摸异常

### DIFF
--- a/dzz/details/template/mobile/components/details/main.htm
+++ b/dzz/details/template/mobile/components/details/main.htm
@@ -19,7 +19,7 @@
 				</div>
 			</template>
 			<template v-else>
-				<div class="img-box" :ref="'BoxImg_'+item.data.dpath+item.type">
+				<div class="img-box" :ref="'BoxImg_'+item.id+item.type">
 					<img :src="item.data.icondata" class="image-viewer__img thumbnail" />
 					<img
 						@load="MainImgload"

--- a/dzz/pichome/template/share/mobile/components/details/main.htm
+++ b/dzz/pichome/template/share/mobile/components/details/main.htm
@@ -19,7 +19,7 @@
 				</div>
 			</template>
 			<template v-else>
-				<div class="img-box" :ref="'BoxImg_'+item.data.dpath+item.type">
+				<div class="img-box" :ref="'BoxImg_'+item.id+item.type">
 					<img :src="item.data.icondata" class="image-viewer__img thumbnail" />
 					<img
 						@load="MainImgload"


### PR DESCRIPTION
问题：
图片详情页中图片容器的 DOM id 生成与使用不一致，导致无法正确获取元素。

原因：
渲染时使用 item.data.dpath，但初始化缩放时使用 item.id，两者不匹配。

修复：
统一使用 item.id 作为图片容器的 DOM id。

影响：
修复移动端图片缩放（PinchZoom）和相关触摸交互失效的问题。