### PR TITLE
fix: sanitize ORDER BY parameter to prevent SQL injection

### DIFF
--- a/dzz/shares/admin.php
+++ b/dzz/shares/admin.php
@@ -42,6 +42,7 @@ if($do == 'filelist'){
         $perpage = $limit;
     }
     $order = isset($_GET['order']) ? trim($_GET['order']) : 'desc';
+    if(!in_array($order, array('desc', 'asc'))) $order = 'desc';
     $orderby = isset($_GET['orderby']) ? trim($_GET['orderby']) : 'dateline';
     if(!in_array($orderby,array('dateline'))) $orderby = 'dateline';
     $ordersql="order by $orderby $order";

--- a/dzz/shares/admin.php
+++ b/dzz/shares/admin.php
@@ -41,8 +41,8 @@ if($do == 'filelist'){
         $start = $start+$perpage - $limit;
         $perpage = $limit;
     }
-    $order = isset($_GET['order']) ? trim($_GET['order']) : 'desc';
-    if(!in_array($order, array('desc', 'asc'))) $order = 'desc';
+    $order = isset($_GET['order']) ? strtolower(trim($_GET['order'])) : 'desc';
+    if(!in_array($order, array('desc', 'asc'), true)) $order = 'desc';
     $orderby = isset($_GET['orderby']) ? trim($_GET['orderby']) : 'dateline';
     if(!in_array($orderby,array('dateline'))) $orderby = 'dateline';
     $ordersql="order by $orderby $order";

--- a/dzz/shares/ajax.php
+++ b/dzz/shares/ajax.php
@@ -275,8 +275,8 @@ if($do=='delete') {
 		$start = $start+$perpage - $limit;
 		$perpage = $limit;
 	}
-    $order = isset($_GET['order']) ? trim($_GET['order']) : 'desc';
-    if(!in_array($order, array('desc', 'asc'))) $order = 'desc';
+    $order = isset($_GET['order']) ? strtolower(trim($_GET['order'])) : 'desc';
+    if(!in_array($order, array('desc', 'asc'), true)) $order = 'desc';
     $orderby = isset($_GET['orderby']) ? trim($_GET['orderby']) : 'dateline';
     if(!in_array($orderby,array('dateline'))) $orderby = 'dateline';
     $ordersql="order by $orderby $order";

--- a/dzz/shares/ajax.php
+++ b/dzz/shares/ajax.php
@@ -276,6 +276,7 @@ if($do=='delete') {
 		$perpage = $limit;
 	}
     $order = isset($_GET['order']) ? trim($_GET['order']) : 'desc';
+    if(!in_array($order, array('desc', 'asc'))) $order = 'desc';
     $orderby = isset($_GET['orderby']) ? trim($_GET['orderby']) : 'dateline';
     if(!in_array($orderby,array('dateline'))) $orderby = 'dateline';
     $ordersql="order by $orderby $order";


### PR DESCRIPTION
## Security Fix: Pre-Auth SQL Injection via `order` Parameter

### Summary

This PR fixes a **critical Pre-authentication SQL Injection** vulnerability in the share file listing endpoints. The `$order` parameter (from `$_GET['order']`) is directly interpolated into SQL `ORDER BY` clauses without any sanitization, allowing unauthenticated attackers to inject arbitrary SQL.

**Fixes: https://github.com/zyx0814/FilePress/issues/70**

### Vulnerability Details

| Item | Detail |
|------|--------|
| **Type** | SQL Injection (CWE-89) |
| **Severity** | Critical |
| **Auth Required** | None (Pre-auth) |
| **Attack Vector** | Network / Remote |
| **CVSS Score** | 9.8 (Critical) |

### Root Cause

In `dzz/shares/ajax.php` (L278) and `dzz/shares/admin.php` (L44), the `$order` parameter from user input is used directly in:

```php
$order = isset($_GET['order']) ? trim($_GET['order']) : 'desc';
$ordersql = "order by $orderby $order";  // ← Unsanitized injection point
```

While the adjacent `$orderby` parameter already has proper `in_array()` whitelisting, the `$order` parameter was missed, creating a direct injection point.

### Fix

Added a single-line `in_array()` whitelist check for `$order`, following the **exact same pattern** already used for `$orderby` on the next line:

```php
$order = isset($_GET['order']) ? trim($_GET['order']) : 'desc';
if(!in_array($order, array('desc', 'asc'))) $order = 'desc';  // ← NEW
$orderby = isset($_GET['orderby']) ? trim($_GET['orderby']) : 'dateline';
if(!in_array($orderby,array('dateline'))) $orderby = 'dateline';  // existing
```

### Files Changed

| File | Change |
|------|--------|
| `dzz/shares/ajax.php` | +1 line (whitelist check for `$order`) |
| `dzz/shares/admin.php` | +1 line (whitelist check for `$order`) |

### Impact Assessment

- **Zero functional impact**: The frontend only sends `asc` or `desc` values
- **Minimal code change**: 1 line added per file, following existing code patterns
- **No bypass possible**: Strict string whitelist (not regex or blacklist)

### Reproduction (Before Fix)

```
GET /index.php?mod=shares&do=filelist&order=desc,(SELECT+SLEEP(3)) HTTP/1.1
```

The injected `SLEEP(3)` causes a measurable time delay, confirming blind SQL injection.
