### PR TITLE
fix: validate avatar uploads by detected image type

### DIFF
--- a/user/my/index.php
+++ b/user/my/index.php
@@ -73,8 +73,8 @@ if($do=='getNavigation'){
     if(strpos($info['mime'],'image/')!==0){
         exit(json_encode(array('error' => 'file is not invalite')));
     }
-    $type = pathinfo($files['name'],PATHINFO_EXTENSION);
-    if (!preg_match('/(gif|jpe?g|png)$/i', $type) || !preg_match('/(gif|jpe?g|png)$/i', $files['type'])|| $files['size'] >= 1024 * 1024 * 2) {
+    $type = dzz_safe_upload_image_extension($info['mime']);
+    if (!$type || $files['size'] >= 1024 * 1024 * 2) {
         exit(json_encode(array('error' => 'file is not invalite')));
     }
     $imgpath = './data/avatar/'.md5($uid).'.'.$type;
@@ -327,5 +327,17 @@ function upBase64($base64Data, $uid)
         }
         @unlink($temp);
         return $success;
+    }
+}
+
+if (!function_exists('dzz_safe_upload_image_extension')) {
+    function dzz_safe_upload_image_extension($mime) {
+        $types = array(
+            'image/gif' => 'gif',
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+        );
+        $mime = strtolower(trim($mime));
+        return isset($types[$mime]) ? $types[$mime] : false;
     }
 }

--- a/user/my/profile.php
+++ b/user/my/profile.php
@@ -143,8 +143,8 @@
         if(strpos($info['mime'],'image/')!==0){
             exit(json_encode(array('error' => 'file is not invalite')));
         }
-        $type = pathinfo($files['name'],PATHINFO_EXTENSION);
-        if (!preg_match('/(gif|jpe?g|png)$/i', $type) || !preg_match('/(gif|jpe?g|png)$/i', $files['type'])|| $files['size'] >= 1024 * 1024 * 2) {
+        $type = dzz_safe_upload_image_extension($info['mime']);
+        if (!$type || $files['size'] >= 1024 * 1024 * 2) {
             exit(json_encode(array('error' => 'file is not invalite')));
         }
         $imgpath = './data/avatar/'.md5($uid).'.'.$type;
@@ -187,6 +187,17 @@
             updatecache('setting');
         }
         return true;
+    }
+    if (!function_exists('dzz_safe_upload_image_extension')) {
+        function dzz_safe_upload_image_extension($mime) {
+            $types = array(
+                'image/gif' => 'gif',
+                'image/jpeg' => 'jpg',
+                'image/png' => 'png',
+            );
+            $mime = strtolower(trim($mime));
+            return isset($types[$mime]) ? $types[$mime] : false;
+        }
     }
     function base64EncodeImage ($image_file) {
         $base64_image = '';


### PR DESCRIPTION
Validates avatar uploads using the detected image MIME type from getimagesize(), maps uploads to safe image extensions, and stops trusting the client-supplied Content-Type header.

Validation: php -l user/my/index.php; php -l user/my/profile.php